### PR TITLE
[SGP-11834] Avoid getting every object one-by-one on `browse`

### DIFF
--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -129,7 +129,7 @@ class FileObject(FileObjectAPI):
     def name(self):
         return self.path
 
-    @property
+    @cached_property
     def url(self):
         return default_storage.url(self.name)
 

--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -127,8 +127,12 @@ def browse(request):
 
         # FILTER / SEARCH
         append = False
-        if fileobject.filetype == request.GET.get('filter_type', fileobject.filetype) and get_filterdate(request.GET.get('filter_date', ''), fileobject.date):
-            append = True
+        if fileobject.filetype == request.GET.get('filter_type', fileobject.filetype):
+            filter_date = request.GET.get('filter_date', '')
+            if filter_date and get_filterdate(filter_date, fileobject.date):
+                append = True
+            if not filter_date:
+                append = True
         if request.GET.get('q') and not re.compile(request.GET.get('q').lower(), re.M).search(file.lower()):
             append = False
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class TestCommand(test):
 
 setup(
     name="filebrowser_safe",
-    version="0.5.0",
+    version="0.5.1-sgp11834",
     description="A snapshot of the filebrowser_3 branch of django-filebrowser, "
                 "packaged as a dependency for the Mezzanine CMS for Django.",
     long_description=open("README.rst").read(),


### PR DESCRIPTION
This update's the `browse` view to avoid asking for `.date` for every file, which for GCS does a `_get_blob` which is expensive.

After digging into this, it feels like we may be doing something wrong, or Django's `storage` API needs to return objects in a different way from `listdir`, or this should not be using `listdir`. Ideally filtering and sorting get passed to the storage so that it can optimize on the cloud side.

This small change preserves the existing behavior, but avoids the `.date` call except when `filter_date` is sent, or sorting is by `date` which will still force a get of every object and thus grows network calls to `N` based on file population.